### PR TITLE
Fix/dokka

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Javadoc
+name: Javadoc but Dokka
 
 on:
   push:
@@ -23,12 +23,12 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew javadoc
+      run: ./gradlew dokkaHtml
     - name: GitHub Pages Javadoc
       if: success()
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         enable_jekyll: true
-        publish_dir: build/docs/javadoc
-        destination_dir: javadoc/
+        publish_dir: build/dokka/
+        destination_dir: dokka/

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,12 @@ processResources {
 	}
 }
 
+tasks.withType(dokkaHtml.getClass()).configureEach {
+	pluginsMapConfiguration.set(
+			["org.jetbrains.dokka.base.DokkaBase": """{ "separateInheritedMembers": true}"""]
+	)
+}
+
 tasks.withType(JavaCompile).configureEach {
 	// ensure that the encoding is set to UTF-8, no matter what the system default is
 	// this fixes some edge cases with special characters not displaying correctly


### PR DESCRIPTION
used a config option in `build.gradle` to make a separate tab for inherited functions and properties so that documentation isnt a mess