### PR TITLE
Simplify and fix Scarpet functions class

### DIFF
--- a/common/src/main/java/org/samo_lego/taterzens/compatibility/ModDiscovery.java
+++ b/common/src/main/java/org/samo_lego/taterzens/compatibility/ModDiscovery.java
@@ -21,6 +21,6 @@ public class ModDiscovery {
         DISGUISELIB_LOADED = platform.isModLoaded("disguiselib");
         SERVER_TRANSLATIONS_LOADED = platform.isModLoaded("server_translations_api");
         FABRICTAILOR_LOADED = platform.isModLoaded("fabrictailor");
-        CARPETMOD_LOADED = platform.isModLoaded("carpetmod");
+        CARPETMOD_LOADED = platform.isModLoaded("carpet");
     }
 }

--- a/fabric/src/main/java/org/samo_lego/taterzens/fabric/compatibility/carpet/AdditionalFunctions.java
+++ b/fabric/src/main/java/org/samo_lego/taterzens/fabric/compatibility/carpet/AdditionalFunctions.java
@@ -6,6 +6,7 @@ import carpet.script.value.EntityValue;
 import carpet.script.value.NullValue;
 import carpet.script.value.Value;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
 import org.samo_lego.taterzens.Taterzens;
 import org.samo_lego.taterzens.api.TaterzensAPI;
 import org.samo_lego.taterzens.interfaces.ITaterzenEditor;
@@ -26,9 +27,9 @@ public class AdditionalFunctions {
      * @param name name of taterzen to create.
      * @return created taterzen.
      */
-    @ScarpetFunction(maxParams = 2)
-    public EntityValue spawn_taterzen(ServerPlayer player, String name) {
-        return (EntityValue) EntityValue.of(TaterzensAPI.createTaterzen(player, name));
+    @ScarpetFunction
+    public Entity spawn_taterzen(ServerPlayer player, String name) {
+        return TaterzensAPI.createTaterzen(player, name);
     }
 
     /**
@@ -36,12 +37,9 @@ public class AdditionalFunctions {
      * @param player player to get taterzen from.
      * @return taterzen of player or null if player doesn't have taterzen selected.
      */
-    @ScarpetFunction(maxParams = 1)
-    public Value players_taterzen(ServerPlayer player) {
-        TaterzenNPC npc = ((ITaterzenEditor) player).getNpc();
-        if (npc != null)
-            return EntityValue.of(npc);
-        return NullValue.NULL;
+    @ScarpetFunction
+    public Entity players_taterzen(ServerPlayer player) {
+        return ((ITaterzenEditor) player).getNpc();
     }
 
     /**
@@ -49,12 +47,12 @@ public class AdditionalFunctions {
      * @param id id of taterzen to get.
      * @return taterzen with given id or null if taterzen with given id doesn't exist.
      */
-    @ScarpetFunction(maxParams = 1)
-    public Value taterzen_by_id(int id) {
+    @ScarpetFunction
+    public Entity taterzen_by_id(int id) {
         // Check size of TATERZEN_NPCS
         if (id < Taterzens.TATERZEN_NPCS.size()) {
-            return EntityValue.of((TaterzenNPC) Taterzens.TATERZEN_NPCS.toArray()[id]);
+            return (TaterzenNPC) Taterzens.TATERZEN_NPCS.toArray()[id];
         }
-        return NullValue.NULL;
+        return null;
     }
 }

--- a/fabric/src/main/java/org/samo_lego/taterzens/fabric/compatibility/carpet/AdditionalFunctions.java
+++ b/fabric/src/main/java/org/samo_lego/taterzens/fabric/compatibility/carpet/AdditionalFunctions.java
@@ -26,7 +26,9 @@ public class AdditionalFunctions {
      */
     @ScarpetFunction
     public Entity spawn_taterzen(ServerPlayer player, String name) {
-        return TaterzensAPI.createTaterzen(player, name);
+        TaterzenNPC npc = TaterzensAPI.createTaterzen(player, name);
+        player.getLevel().addFreshEntity(npc);
+        return npc;
     }
 
     /**

--- a/fabric/src/main/java/org/samo_lego/taterzens/fabric/compatibility/carpet/AdditionalFunctions.java
+++ b/fabric/src/main/java/org/samo_lego/taterzens/fabric/compatibility/carpet/AdditionalFunctions.java
@@ -2,9 +2,6 @@ package org.samo_lego.taterzens.fabric.compatibility.carpet;
 
 import carpet.script.annotation.AnnotationParser;
 import carpet.script.annotation.ScarpetFunction;
-import carpet.script.value.EntityValue;
-import carpet.script.value.NullValue;
-import carpet.script.value.Value;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import org.samo_lego.taterzens.Taterzens;


### PR DESCRIPTION
This PR simplifies the Scarpet functions class (AdditionalFunctions.java) to use more of the API simplification and therefore rely less on implementation types.

Draft given I haven't tested this, just coded it in github's editor. However I think it should work (and build passes).

Request for feedback about the API: Do you think it would be useful if the API allowed changing the name of the resulting function in the annotation? Would allow to directly annotate normal functions, given JLS 13.5.7 states removing annotations doesn't cause linkage errors (so the mod should still work without Carpet at runtime).
Also any other feedback is appreciated!