### PR TITLE
Some experiments with improving tab list behaviour

### DIFF
--- a/common/src/main/java/org/samo_lego/taterzens/mixin/network/ServerGamePacketListenerImplMixin_PacketFaker.java
+++ b/common/src/main/java/org/samo_lego/taterzens/mixin/network/ServerGamePacketListenerImplMixin_PacketFaker.java
@@ -1,11 +1,9 @@
 package org.samo_lego.taterzens.mixin.network;
 
 import com.mojang.authlib.GameProfile;
-import com.mojang.datafixers.util.Pair;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import net.minecraft.network.Connection;
-import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundAddPlayerPacket;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket;
@@ -26,6 +24,7 @@ import org.samo_lego.taterzens.mixin.accessors.ClientboundPlayerInfoPacketAccess
 import org.samo_lego.taterzens.mixin.accessors.ClientboundSetEntityDataPacketAccessor;
 import org.samo_lego.taterzens.mixin.accessors.EntityAccessor;
 import org.samo_lego.taterzens.npc.TaterzenNPC;
+import org.samo_lego.taterzens.util.NpcPlayerUpdate;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -35,9 +34,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.ArrayDeque;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Queue;
 
 import static net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket.Action.ADD_PLAYER;
 import static net.minecraft.network.protocol.game.ClientboundPlayerInfoPacket.Action.REMOVE_PLAYER;
@@ -61,9 +60,9 @@ public abstract class ServerGamePacketListenerImplMixin_PacketFaker {
     @Unique
     private boolean taterzens$skipCheck;
     @Unique
-    private final List<Pair<GameProfile, Component>> taterzens$tablistQueue = new ArrayList<>();
+    private final Queue<NpcPlayerUpdate> taterzens$tablistQueue = new ArrayDeque<>();
     @Unique
-    private int taterzens$queueTimer;
+    private int taterzens$queueTick;
 
     /**
      * Changes entity type if entity is an instance of {@link TaterzenNPC}.
@@ -91,7 +90,7 @@ public abstract class ServerGamePacketListenerImplMixin_PacketFaker {
             ClientboundPlayerInfoPacket playerAddPacket = new ClientboundPlayerInfoPacket(ADD_PLAYER);
             //noinspection ConstantConditions
             ((ClientboundPlayerInfoPacketAccessor) playerAddPacket).setEntries(
-                    Arrays.asList(new ClientboundPlayerInfoPacket.PlayerUpdate(profile, 0, GameType.SURVIVAL, npc.getTabListName()))
+                List.of(new ClientboundPlayerInfoPacket.PlayerUpdate(profile, 0, GameType.SURVIVAL, npc.getTabListName()))
             );
             this.send(playerAddPacket);
 
@@ -108,8 +107,7 @@ public abstract class ServerGamePacketListenerImplMixin_PacketFaker {
             // If player is immediately removed from the tablist,
             // client doesn't care about the skin.
             if(config.taterzenTablistTimeout != -1) {
-                this.taterzens$tablistQueue.add(new Pair<>(npc.getGameProfile(), npc.getTabListName()));
-                this.taterzens$queueTimer = config.taterzenTablistTimeout;
+                this.taterzens$tablistQueue.add(new NpcPlayerUpdate(npc.getGameProfile(), npc.getTabListName(), taterzens$queueTick + config.taterzenTablistTimeout));
             }
 
             this.connection.send(new ClientboundRotateHeadPacket(entity, (byte)((int)(entity.getYHeadRot() * 256.0F / 360.0F))), listener);
@@ -138,36 +136,33 @@ public abstract class ServerGamePacketListenerImplMixin_PacketFaker {
             ((ClientboundPlayerInfoPacketAccessor) packet).getEntries().forEach(entry -> {
                 if(entry.getProfile().getName().equals("-" + config.defaults.name + "-")) {
                     // Fixes unloaded taterzens showing in tablist (disguiselib)
-                    this.taterzens$tablistQueue.add(new Pair<>(entry.getProfile(), entry.getDisplayName()));
+                    this.taterzens$tablistQueue.add(new NpcPlayerUpdate(entry.getProfile(), entry.getDisplayName(), taterzens$queueTick + config.taterzenTablistTimeout));
                 }
             });
-            this.taterzens$queueTimer = config.taterzenTablistTimeout;
         }
     }
 
     @Inject(method = "handleMovePlayer(Lnet/minecraft/network/protocol/game/ServerboundMovePlayerPacket;)V", at = @At("RETURN"))
     private void removeTaterzenFromTablist(ServerboundMovePlayerPacket packet, CallbackInfo ci) {
-        if(!this.taterzens$tablistQueue.isEmpty() && --this.taterzens$queueTimer <= 0) {
-            this.taterzens$skipCheck = true;
+        if(taterzens$tablistQueue.isEmpty()) return;
 
-            ClientboundPlayerInfoPacket taterzensRemovePacket = new ClientboundPlayerInfoPacket(REMOVE_PLAYER);
-            List<ClientboundPlayerInfoPacket.PlayerUpdate> taterzenList = this.taterzens$tablistQueue
-                    .stream()
-                    .map(pair -> new ClientboundPlayerInfoPacket.PlayerUpdate(
-                                    pair.getFirst(),
-                                    0,
-                                    GameType.SURVIVAL,
-                                    pair.getSecond()
-                            )
-                    )
-                    .collect(Collectors.toList());
-            //noinspection ConstantConditions
-            ((ClientboundPlayerInfoPacketAccessor) taterzensRemovePacket).setEntries(taterzenList);
-            this.send(taterzensRemovePacket);
+        taterzens$queueTick++;
 
-            this.taterzens$tablistQueue.clear();
+        List<ClientboundPlayerInfoPacket.PlayerUpdate> toRemove = new ArrayList<>(0);
+        while(true) {
+            NpcPlayerUpdate current = taterzens$tablistQueue.peek();
+            if(current == null || current.removeAt() > taterzens$queueTick) break;
 
-            this.taterzens$skipCheck = false;
+            taterzens$tablistQueue.remove();
+            toRemove.add(new ClientboundPlayerInfoPacket.PlayerUpdate(current.profile(), 0, GameType.SURVIVAL, current.displayName()));
         }
+
+        ClientboundPlayerInfoPacket taterzensRemovePacket = new ClientboundPlayerInfoPacket(REMOVE_PLAYER);
+        //noinspection ConstantConditions
+        ((ClientboundPlayerInfoPacketAccessor) taterzensRemovePacket).setEntries(toRemove);
+
+        this.taterzens$skipCheck = true;
+        this.send(taterzensRemovePacket);
+        this.taterzens$skipCheck = false;
     }
 }

--- a/common/src/main/java/org/samo_lego/taterzens/mixin/network/ServerGamePacketListenerImplMixin_PacketFaker.java
+++ b/common/src/main/java/org/samo_lego/taterzens/mixin/network/ServerGamePacketListenerImplMixin_PacketFaker.java
@@ -33,6 +33,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -91,7 +92,7 @@ public abstract class ServerGamePacketListenerImplMixin_PacketFaker {
             ClientboundPlayerInfoPacket playerAddPacket = new ClientboundPlayerInfoPacket(ADD_PLAYER);
             //noinspection ConstantConditions
             ((ClientboundPlayerInfoPacketAccessor) playerAddPacket).setEntries(
-                List.of(new ClientboundPlayerInfoPacket.PlayerUpdate(profile, 0, GameType.SURVIVAL, npc.getTabListName()))
+                Arrays.asList(new ClientboundPlayerInfoPacket.PlayerUpdate(profile, 0, GameType.SURVIVAL, npc.getTabListName()))
             );
             this.send(playerAddPacket);
 

--- a/common/src/main/java/org/samo_lego/taterzens/mixin/network/ServerGamePacketListenerImplMixin_PacketFaker.java
+++ b/common/src/main/java/org/samo_lego/taterzens/mixin/network/ServerGamePacketListenerImplMixin_PacketFaker.java
@@ -153,7 +153,7 @@ public abstract class ServerGamePacketListenerImplMixin_PacketFaker {
 
         taterzens$queueTick++;
 
-        List<ClientboundPlayerInfoPacket.PlayerUpdate> toRemove = new ArrayList<>(0);
+        List<ClientboundPlayerInfoPacket.PlayerUpdate> toRemove = new ArrayList<>();
         for(var iterator = taterzens$tablistQueue.values().iterator(); iterator.hasNext(); ) {
             var current = iterator.next();
             if(current.removeAt() > taterzens$queueTick) break;
@@ -161,6 +161,7 @@ public abstract class ServerGamePacketListenerImplMixin_PacketFaker {
             iterator.remove();
             toRemove.add(new ClientboundPlayerInfoPacket.PlayerUpdate(current.profile(), 0, GameType.SURVIVAL, current.displayName()));
         }
+        if(toRemove.isEmpty()) return;
 
         ClientboundPlayerInfoPacket taterzensRemovePacket = new ClientboundPlayerInfoPacket(REMOVE_PLAYER);
         //noinspection ConstantConditions

--- a/common/src/main/java/org/samo_lego/taterzens/mixin/network/ServerGamePacketListenerImplMixin_PacketFaker.java
+++ b/common/src/main/java/org/samo_lego/taterzens/mixin/network/ServerGamePacketListenerImplMixin_PacketFaker.java
@@ -91,7 +91,7 @@ public abstract class ServerGamePacketListenerImplMixin_PacketFaker {
             ClientboundPlayerInfoPacket playerAddPacket = new ClientboundPlayerInfoPacket(ADD_PLAYER);
             //noinspection ConstantConditions
             ((ClientboundPlayerInfoPacketAccessor) playerAddPacket).setEntries(
-                    Arrays.asList(new ClientboundPlayerInfoPacket.PlayerUpdate(profile, 0, GameType.SURVIVAL, npc.getName()))
+                    Arrays.asList(new ClientboundPlayerInfoPacket.PlayerUpdate(profile, 0, GameType.SURVIVAL, npc.getTabListName()))
             );
             this.send(playerAddPacket);
 
@@ -108,7 +108,7 @@ public abstract class ServerGamePacketListenerImplMixin_PacketFaker {
             // If player is immediately removed from the tablist,
             // client doesn't care about the skin.
             if(config.taterzenTablistTimeout != -1) {
-                this.taterzens$tablistQueue.add(new Pair<>(npc.getGameProfile(), npc.getName()));
+                this.taterzens$tablistQueue.add(new Pair<>(npc.getGameProfile(), npc.getTabListName()));
                 this.taterzens$queueTimer = config.taterzenTablistTimeout;
             }
 

--- a/common/src/main/java/org/samo_lego/taterzens/npc/TaterzenNPC.java
+++ b/common/src/main/java/org/samo_lego/taterzens/npc/TaterzenNPC.java
@@ -9,6 +9,7 @@ import com.mojang.authlib.properties.PropertyMap;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.math.Vector3f;
 import io.netty.buffer.Unpooled;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -606,6 +607,15 @@ public class TaterzenNPC extends PathfinderMob implements CrossbowAttackMob, Ran
 
     public GameProfile getGameProfile() {
         return this.gameProfile;
+    }
+
+    public Component getTabListName() {
+        if(!config.obscureTabList) return getName();
+
+        var component =  new TextComponent("").withStyle(ChatFormatting.DARK_GRAY);
+        component.append(getName());
+        component.append(" [NPC]");
+        return component;
     }
 
     /**

--- a/common/src/main/java/org/samo_lego/taterzens/storage/TaterConfig.java
+++ b/common/src/main/java/org/samo_lego/taterzens/storage/TaterConfig.java
@@ -85,6 +85,9 @@ public class TaterConfig implements IBrigadierConfigurator {
     @SerializedName("lock_after_creation")
     public boolean lockAfterCreation = true;
 
+    @SerializedName("// Obsucre Taterzens' names while they are visible on the tab list.")
+    public boolean obscureTabList = true;
+
     @SerializedName("// Default settings for new Taterzens.")
     public final String _comment_defaults = "";
     public Defaults defaults = new Defaults();

--- a/common/src/main/java/org/samo_lego/taterzens/util/NpcPlayerUpdate.java
+++ b/common/src/main/java/org/samo_lego/taterzens/util/NpcPlayerUpdate.java
@@ -1,0 +1,15 @@
+package org.samo_lego.taterzens.util;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.network.chat.Component;
+
+/**
+ * An NPC which is queued to be removed from the tab list at a future point.
+ *
+ * @param profile     The game profile we're removing from the tab list.
+ * @param displayName The NPC's display name.
+ * @param removeAt    The tick at which this NPC should be removed.
+ * @see org.samo_lego.taterzens.mixin.network.ServerGamePacketListenerImplMixin_PacketFaker
+ */
+public record NpcPlayerUpdate(GameProfile profile, Component displayName, long removeAt) {
+}


### PR DESCRIPTION
This is just a couple of experiments I had for reducing the player list noise on the Blanketcon server. I don't know if any of these ideas are sensible/desirable, so feel free to ignore if not!

 - Add a config option (default by true) to render NPC names in dark grey on the tab list, with ` [NPC]` appended, hopefully making it clearer that this isn't a real player.

 - Maintain a queue of when to remove players from the tab list, rather than resetting the timer on each change. I'm not 100% comfortable with this change - this appears to work correctly, but looking through the change history there's definitely some edge cases you've had to handle and I'm not sure if this will cause any regressions.

One thing I wasn't sure about was why `removeTaterzenFromTablist` hooks into `onPlayerMove` rather than `tick` - I assume this is to cope with clients which might be lagging a bit?