### PR TITLE
Fixed crash bug in Fabric 1.18.2 (Update dependencies)

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 
     // Carpet
     //modImplementation("carpet:fabric-carpet:${rootProject.minecraft_version}-${project.carpet_core_version}")
-    modCompileOnly("carpet:fabric-carpet:1.18-pre4-${project.carpet_core_version}")
+    modCompileOnly("carpet:fabric-carpet:${project.carpet_core_version}")
 
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive false }

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,1 +1,1 @@
-carpet_core_version = 1.4.54+v211117
+carpet_core_version = 1.18.2-1.4.69+v220331

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,21 +3,21 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 minecraft_version=1.18.2
-yarn_mappings=1.18.2+build.1
-loader_version=0.13.3
+yarn_mappings=1.18.2+build.4
+loader_version=0.14.9
 
 #Fabric api
-fabric_version=0.47.8+1.18.2
+fabric_version=0.58.0+1.18.2
 
 #Forge
 forge_version=39.0.10
 
 # Mod Properties
-mod_version = 1.8.4
+mod_version = 1.8.5
 maven_group = org.samo_lego
 archives_base_name = taterzens
 
 # Dependencies
-disguiselib_version = 1.2.1
-c2b_version = 1.1.1
-sgui_version = 1.0.0-rc5+1.18+pre5
+disguiselib_version = 1.2.2
+c2b_version = 1.1.2
+sgui_version = 1.0.2+1.18.2


### PR DESCRIPTION
Crash after loading world when running with Fabric 1.18.2.
I fixed the dependencies.
Now it works.