### PR TITLE
Register Scarpet trait command only if Carpet is loaded and init profession later

### DIFF
--- a/fabric/src/main/java/org/samo_lego/taterzens/fabric/TaterzensFabric.java
+++ b/fabric/src/main/java/org/samo_lego/taterzens/fabric/TaterzensFabric.java
@@ -5,7 +5,6 @@ import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import org.samo_lego.taterzens.Taterzens;
-import org.samo_lego.taterzens.api.TaterzensAPI;
 import org.samo_lego.taterzens.commands.edit.messages.MessagesReorderCommand;
 import org.samo_lego.taterzens.fabric.compatibility.carpet.AdditionalFunctions;
 import org.samo_lego.taterzens.fabric.compatibility.carpet.ScarpetProfession;
@@ -28,7 +27,6 @@ public class TaterzensFabric implements ModInitializer {
 
         // CarpetMod
         if (CARPETMOD_LOADED) {
-            TaterzensAPI.registerProfession(ScarpetProfession.ID, ScarpetProfession::new);
             AdditionalFunctions.init();
         }
 
@@ -36,7 +34,9 @@ public class TaterzensFabric implements ModInitializer {
         CommandRegistrationCallback.EVENT.register((dispatcher, context, selection) -> {
             Taterzens.registerCommands(dispatcher, context);
             MessagesReorderCommand.register(dispatcher);
-            ScarpetTraitCommand.register();
+            if (CARPETMOD_LOADED) {
+                ScarpetTraitCommand.register(); // also registers profession on first init
+            }
         });
 
         UseBlockCallback.EVENT.register(new BlockInteractEventImpl());

--- a/fabric/src/main/java/org/samo_lego/taterzens/fabric/compatibility/carpet/ScarpetTraitCommand.java
+++ b/fabric/src/main/java/org/samo_lego/taterzens/fabric/compatibility/carpet/ScarpetTraitCommand.java
@@ -15,6 +15,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 import org.samo_lego.taterzens.Taterzens;
+import org.samo_lego.taterzens.api.TaterzensAPI;
 import org.samo_lego.taterzens.api.professions.TaterzenProfession;
 import org.samo_lego.taterzens.commands.NpcCommand;
 import org.samo_lego.taterzens.interfaces.ITaterzenEditor;
@@ -35,9 +36,13 @@ import static org.samo_lego.taterzens.util.TextUtil.successText;
 import static org.samo_lego.taterzens.util.TextUtil.translate;
 
 public class ScarpetTraitCommand {
+    static {
+        TaterzensAPI.registerProfession(ScarpetProfession.ID, ScarpetProfession::new);
+    }
+
     public static void register() {
         LiteralCommandNode<CommandSourceStack> scarpet = literal("scarpetTraits")
-                .requires(src -> CARPETMOD_LOADED && Taterzens.getInstance().getPlatform().checkPermission(src, "taterzens.profession.scarpet", config.perms.professionCommandPL))
+                .requires(src -> Taterzens.getInstance().getPlatform().checkPermission(src, "taterzens.profession.scarpet", config.perms.professionCommandPL))
                 .then(literal("add")
                         .requires(src -> Taterzens.getInstance().getPlatform().checkPermission(src, "taterzens.profession.scarpet.add", config.perms.professionCommandPL))
                         .then(argument("id", StringArgumentType.word())


### PR DESCRIPTION
About the command, it makes it register only if Carpet is loaded, given else it's just wasted memory and a check per player when syncing command. It's not the main purpose of the PR.

About initializing the profession later, there's currently an issue-ish where Carpet is sensitive to the load order with the `CarpetEventServer.Event` class. If it's initialized too early, when entities from mods that haven't had their initializers run yet will generate a log entry each time they spawn (and will have less functionality in scarpet). Taterzens was causing this with the chain `TaterzensFabric.onInitialize` > `ScarpetProfession::new` > `ScarpetProfession static` > `TaterzenScarpetEvent extends` > `CarpetEventServer.Event` (found in gnembon/fabric-carpet#1647).
The fix was moving it to the class initialization of the command, given it runs later, late enough that most mods should've registered their entities. It's not the best of fixes, but it does the job.

I want this to be fixed in Carpet but I haven't done it yet and it likely won't be on 1.19.3, so I'm PRing this fix/workaround so it's not an issue with taterzens on 1.19.3.

This issue is also present in 1.19.2, though idk if you do backports.