### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/en/getting_started/behaviour.md
+++ b/docs/en/getting_started/behaviour.md
@@ -28,7 +28,7 @@ To achieve that, use
 
 ## Teaming them up
 
-Taterzen teams use the vanilla teams system. For extra docs on the team command, see the [wiki](https://minecraft.fandom.com/wiki/Commands/team#Syntax).
+Taterzen teams use the vanilla teams system. For extra docs on the team command, see the [wiki](https://minecraft.wiki/w/Commands/team#Syntax).
 To create and add taterzens to a team, you can simply do
 ```
 /team add teamName

--- a/docs/en/getting_started/command_actions/bungee_actions.md
+++ b/docs/en/getting_started/command_actions/bungee_actions.md
@@ -24,7 +24,7 @@ where
 ## Available commands
 * `server` - transfers player to another server (parameter: server name)
 * `message` - sends message to the player
-* `message_raw` - sends message to the player in [tellraw](https://minecraft.fandom.com/wiki/Raw_JSON_text_format) format
+* `message_raw` - sends message to the player in [tellraw](https://minecraft.wiki/w/Raw_JSON_text_format) format
 * `kick` - kicks player (parameter: reason for kick)
 
 ## Server redirect

--- a/docs/en/getting_started/commands/npc_command.md
+++ b/docs/en/getting_started/commands/npc_command.md
@@ -31,7 +31,7 @@ You can select NPCs by their ID, name, UUID or based on proximity and look direc
 _Note:_ The ID means the list index number which is shown when you run the `/npc list` command. 
 (The first number before the name.) Contrary, the UUID is the _**u**niversally **u**nique **id**entifier_
 as used internally by Minecraft to uniquely distinguish between entities. 
-(See Minecraft Wiki: https://minecraft.fandom.com/wiki/Universally_unique_identifier )
+(See Minecraft Wiki: https://minecraft.wiki/w/Universally_unique_identifier )
 
 #### **Id**
 1. Run `/npc list` to view the IDs of available NPCs.

--- a/docs/en/getting_started/sounds.md
+++ b/docs/en/getting_started/sounds.md
@@ -157,6 +157,6 @@ Alternatively without the namespace:
 
 Note that for addressing the sound with the index, you need the `index` keyword after you specified the sound category, 
 while you have to use the `resource` keyword in order to remove the sound by using its name. (Technically the name 
-represents a so-called _resource location_. See Minecraft-Wiki: https://minecraft.fandom.com/wiki/Resource_location )
+represents a so-called _resource location_. See Minecraft-Wiki: https://minecraft.wiki/w/Resource_location )
 
 _Remember:_ Tab-completion makes your life easier!

--- a/docs/zh/getting_started/command_actions/bungee_actions.md
+++ b/docs/zh/getting_started/command_actions/bungee_actions.md
@@ -24,7 +24,7 @@ title: 跨服操作
 ## 可用指令
 * `server` - 将玩家传送到另外一个服务器上。（参数：服务器名称）
 * `message` - 向玩家发送的信息。
-* `message_raw` - 以[tellraw](https://minecraft.fandom.com/wiki/Raw_JSON_text_format)格式向玩家发送信息。
+* `message_raw` - 以[tellraw](https://minecraft.wiki/w/Raw_JSON_text_format)格式向玩家发送信息。
 * `kick` - 踢出玩家（参数：踢出原因）
 
 ## 服务器切换

--- a/docs/zh/getting_started/sounds.md
+++ b/docs/zh/getting_started/sounds.md
@@ -141,6 +141,6 @@ NPC将会彻底静音！
 
 `/npc edit sounds remove ambient resource entity.villager.ambient`
 
-如果想根据索引来处理声音的话，需要在声音的类型中添加索引的关键字，不使用关键词将无法删除声音，从技术上来说这指的是声音资源路径，详细请参考[我的世界wiki](https://minecraft.fandom.com/wiki/Resource_location)
+如果想根据索引来处理声音的话，需要在声音的类型中添加索引的关键字，不使用关键词将无法删除声音，从技术上来说这指的是声音资源路径，详细请参考[我的世界wiki](https://minecraft.wiki/w/Resource_location)
 
 _Remember:_ 使用Tab键来补全指令会让操作更简单！


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki