### PR TITLE
Fix #137 (rewrite/polymer)

### DIFF
--- a/src/main/java/org/samo_lego/taterzens/common/npc/TaterzenNPC.java
+++ b/src/main/java/org/samo_lego/taterzens/common/npc/TaterzenNPC.java
@@ -508,7 +508,7 @@ public class TaterzenNPC extends PathfinderMob implements CrossbowAttackMob, Ran
                 // as we need the original list below
                 if (((ITaterzenEditor) player).getEditorMode() == ITaterzenEditor.EditorMode.MESSAGES) {
                     continue;
-                } //  || this.distanceTo(player) > config.messages.speakDistance
+                }
 
                 ITaterzenPlayer pl = (ITaterzenPlayer) player;
                 int msgPos = pl.getLastMsgPos(this.getUUID());

--- a/src/main/java/org/samo_lego/taterzens/common/npc/TaterzenNPC.java
+++ b/src/main/java/org/samo_lego/taterzens/common/npc/TaterzenNPC.java
@@ -499,16 +499,16 @@ public class TaterzenNPC extends PathfinderMob implements CrossbowAttackMob, Ran
     public void tick() {
         super.tick();
 
-        AABB box = this.getBoundingBox().inflate(4.0D);
+        AABB box = this.getBoundingBox().inflate(config.messages.speakDistance);
         List<ServerPlayer> players = this.level().getEntitiesOfClass(ServerPlayer.class, box);
 
         if (!this.npcData.messages.isEmpty()) {
             for (ServerPlayer player : players) {
                 // Filter them here (not use a predicate above)
                 // as we need the original list below
-                if (((ITaterzenEditor) player).getEditorMode() == ITaterzenEditor.EditorMode.MESSAGES || this.distanceTo(player) > config.messages.speakDistance) {
+                if (((ITaterzenEditor) player).getEditorMode() == ITaterzenEditor.EditorMode.MESSAGES) {
                     continue;
-                }
+                } //  || this.distanceTo(player) > config.messages.speakDistance
 
                 ITaterzenPlayer pl = (ITaterzenPlayer) player;
                 int msgPos = pl.getLastMsgPos(this.getUUID());

--- a/src/main/resources/taterzens.common.mixins.json
+++ b/src/main/resources/taterzens.common.mixins.json
@@ -23,6 +23,5 @@
   "client": [],
   "injectors": {
     "defaultRequire": 1
-  },
-  "refmap": "${refmap}"
+  }
 }


### PR DESCRIPTION
Fixes the speak_distance (#137) issue

## The issue
What did I do (read the [comment](https://github.com/samolego/Taterzens/issues/137#issuecomment-1985412261) first):
- In `TaterzenNPC`'s `tick()` implementation, pass the speakDistance config value instead of 4.0D to the `AABB`'s `inflate()` method
- Removed redundant check 7 lines later, in the `for` loop. Distance is applied anyway, on the box calculation step. This decision is questionable tho, lmk what you think @samolego 

Here's some screenshots of [Minecraft](https://github.com/samolego/Taterzens/assets/49122140/4f52459e-fbaa-40f8-8ea4-79a99084b7f6) and [config file](https://github.com/samolego/Taterzens/assets/49122140/e3435007-87a0-4e24-ae38-4271c18b82fe)

## A little bit more
Also, some additional fixes:
- For some reason, there was a `"refmap": "${refmap}"` in the common mixin config, but I didn't find any mentions of it in the build setup. It was preventing the mod from launching (lol), because Mixin was failing to locate this non-existent refmap (it also said so). Furthermore, such a pattern isn't present in client mixin config. What I did is removed the line, details explained in a [commit](https://github.com/MagicSweet-dev/Taterzens/commit/2f432a71f2fda76838deda6058d2792a88ed5aae) description. Again, up to debate, but the mod doesn't even start without it.