### PR TITLE
Java 21 and Gradle 8.8

### DIFF
--- a/.github/workflows/fabric-build.yml
+++ b/.github/workflows/fabric-build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 23
+          java-version: 21
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build

--- a/.github/workflows/fabric-release.yml
+++ b/.github/workflows/fabric-release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 23
+          java-version: 21
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/javadoc-snapshot.yml
+++ b/.github/workflows/javadoc-snapshot.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 23
+          java-version: 21
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 23
+          java-version: 21
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 23
+          java-version: 21
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ curseforge {
         addGameVersion "Fabric"
         addGameVersion "Quilt"
 
-        mainArtifact(file("${project.buildDir}/libs/${archivesBaseName}-${version}-fabric.jar")) {
+        mainArtifact(file("${project.layout.buildDirectory}/libs/${base.archivesName}-${version}-fabric.jar")) {
             displayName = "[${project.minecraft_version}] Taterzens ${version}"
         }
 
@@ -157,7 +157,7 @@ modrinth {
     changelog = ENV.CHANGELOG ?: "A changelog can be found at https://github.com/samolego/Taterzens/releases/tag/${version}"
     versionName = "[${project.minecraft_version}] Taterzens ${version} [Fabric]"
 
-    uploadFile = file("${project.buildDir}/libs/${archivesBaseName}-${version}-fabric.jar")
+    uploadFile = file("${project.layout.buildDirectory}/libs/${base.archivesName}-${version}-fabric.jar")
 
     gameVersions = ["${project.minecraft_version}"]
     loaders = ['fabric', 'quilt']

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
     // One of the big changes to 1.21 is a requirement for at least Java 21, using 22 as it's current at time of dev.
-    it.options.release = 22
+    it.options.release = 21
 }
 
 java {
@@ -92,8 +92,8 @@ java {
     // If you remove this line, sources will not be generated.
     withSourcesJar()
 
-    sourceCompatibility = JavaVersion.VERSION_22
-    targetCompatibility = JavaVersion.VERSION_22
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 jar {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Hi! here's the PR for the Java 21 change. (#193)

While i was at it i also noticed that the Gradle wrapper was still on Gradle 8.5 despite Loom 1.7 requiring at least Gradle 8.8 so i updated that too and cleaned up a few remaining uses of deprecated features of Gradle. All the Gradle stuff is in a separate commit in case you'd rather do those changes separately or part of some other PR.